### PR TITLE
plot_residual_vpaに渡す引数を実際にvpaで利用しているものに変更

### DIFF
--- a/R/diagnostics_vpa.R
+++ b/R/diagnostics_vpa.R
@@ -616,6 +616,8 @@ plot_residual_vpa <- function(res, index_name = NULL, plot_smooth = FALSE, plot_
   } else {
     assertthat::assert_that(is.numeric(res$input$use.index)|res$input$use.index=="all")
   }
+  
+ 
   # x軸の範囲
   if(is.numeric(plot_year)) xlim_year <- c(min(plot_year), max(plot_year)) else xlim_year <- c(min(as.numeric(colnames(res_vpa_estb$naa))), max(as.numeric(colnames(res_vpa_estb$naa))))
 
@@ -633,31 +635,22 @@ plot_residual_vpa <- function(res, index_name = NULL, plot_smooth = FALSE, plot_
   name_tmp1 <- name_tmp2 <- name_tmp3 <- name_tmp4 <- name_tmp5 <- numeric()
 
   for(i in 1:length(res$q)){
-    if(length(res$input$min.age)==1) min_age_tmp <- res$input$min.age[1] else min_age_tmp <- res$input$min.age[i]
-    if(length(res$input$min.age)==1) max_age_tmp <- res$input$max.age[1] else max_age_tmp <- res$input$max.age[i]
+    if(length(res$min.age)==1) min_age_tmp <- res$min.age[1] else min_age_tmp <- res$min.age[i]
+    if(length(res$min.age)==1) max_age_tmp <- res$max.age[1] else max_age_tmp <- res$max.age[i]
 
     resid_tmp <- log(d_tmp[,i+1]) - log(res$pred.index[i,]) # 対数残差
     sd_resid_tmp <- resid_tmp/sd(resid_tmp, na.rm = TRUE) # 対数残差の標準化残差
 
     #abund.extractor関数で書き換え #catch.prop引数は不要か
-	if (res$input$use.index[1]!="all") {
-	d_tmp[,(i+length(res$q)*1+4)] <- abund.extractor(abund = res$input$abund[res$input$use.index[i]], naa = res$naa, faa = res$faa,
+	#use.indexを使用した場合のif文は必要なくなったので消去
+	d_tmp[,(i+length(res$q)*1+4)] <- abund.extractor(abund = res$abund[i], naa = res$naa, faa = res$faa,
                                                      dat = res$input$dat,
-                                                     min.age = res$input$min.age[res$input$use.index[i]], max.age = res$input$max.age[res$input$use.index[i]],
-                                                     link = res$input$link[res$input$use.index[i]], base = res$input$base, af = res$input$af,
+                                                     min.age = res$min.age[i], max.age = res$max.age[i],
+                                                     link = res$link[i], base = res$base, af = res$af,
                                                      sel.def = res$input$sel.def, p.m=res$input$p.m,
                                                      omega=res$input$omega, scale=1) #res$input$scale)
                                                     #res$ssbはスケーリングしていない結果が出ている(2021/06/09KoHMB)
-	}
-	else{
-    d_tmp[,(i+length(res$q)*1+4)] <- abund.extractor(abund = res$input$abund[i], naa = res$naa, faa = res$faa,
-                                                     dat = res$input$dat,
-                                                     min.age = res$input$min.age[i], max.age = res$input$max.age[i],
-                                                     link = res$input$link[i], base = res$input$base, af = res$input$af,
-                                                     sel.def = res$input$sel.def, p.m=res$input$p.m,
-                                                     omega=res$input$omega, scale=1) #res$input$scale)
-                                                    #res$ssbはスケーリングしていない結果が出ている(2021/06/09KoHMB)
-    }
+	
     d_tmp[,(i+length(res$q)*2+4)] <- res$pred.index[i,] # q*N^B計算結果
     d_tmp[,(i+length(res$q)*3+4)] <- resid_tmp
     d_tmp[,(i+length(res$q)*4+4)] <- sd_resid_tmp

--- a/R/rvpa.r
+++ b/R/rvpa.r
@@ -1549,9 +1549,13 @@ Ft <- mean(faa[,ny],na.rm=TRUE)
   Fc.max <- max(Fc.at.age,na.rm=TRUE)
 
   res <- list(input=arglist, term.f=term.f, np=np, minimum=out$minimum, minimum.c=out$minimum.c, logLik=logLik, gradient=gradient, code=code, q=q, b=b, sigma=sigma, convergence=convergence, message=message, hessian=hessian, Ft=Ft, Fc.at.age=Fc.at.age, Fc.mean=Fc.mean, Fc.max=Fc.max, last.year=last.year, Pope=Pope, ssb.coef=ssb.coef, pred.index=pred.index, wcaa=caa*waa.catch,naa=naa, faa=faa, baa=baa, ssb=ssb, saa=saa)
-
+  
+  invisible(res2 <- list(input=arglist, use.index=use.index, abund=abund, min.age=min.age, max.age=max.age, link=link, base=base, af=af, index.w=index.w, q=q, naa=naa, faa=faa, baa=baa, ssb=ssb, pred.index=pred.index, sigma=sigma, b=b)) #use.indexを考慮し，実際にVPAのチューニングで与えた値
+  
+  print(list(use.index=use.index, abund=abund, min.age=min.age, max.age=max.age, link=link, base=base, af=af, index.w=index.w))
+  
   if (isTRUE(plot) & isTRUE(tune)){
-    graph <- try(plot_residual_vpa(res, index_name = NULL, plot_year = plot.year)) # plot.yearに対応する引数を追加してください
+    graph <- try(plot_residual_vpa(res2, index_name = NULL, plot_year = plot.year)) # plot.yearに対応する引数を追加してください
     if(class(graph)=="try-error"){
       for (i in 1:nindex){
         Y <- years %in% plot.year


### PR DESCRIPTION
@KoHMB さま　@ichimomoさま

何度も修正すみません．
plot_residual_vpaが参照している引数が以前は，vpaのinputにある値だったため，use.indexを利用しているときなどで，チューニングに関するパラメータの引数が指数の長さ分inputとして与えられていないと，plotが上手くいかないということがありました．
ので今まではvpaのほうで警告を出して，use.indexを使用しているときは，チューニングに関するパラメータのinputの長さを指数のlengthに揃えましょうと言っていたのですが，これだとjackknifeで警告が出たりして不具合があったのと，vpaの計算の中では指数分の長さがない場合は補正してうまく走せていたので，これを利用して，plot_residual_vpaでres$inputを参照するのではなく，実際にVPAで用いた設定(res2を新たに作成）を参照するように変更することで問題を解消しました．

こちらのテストではこれで上手くいくことを確認していますが，一応濱邉さんのdiagnosticsテストでも問題が新たにないか確認いただけると幸いです．お手数おかけしてすみませんが宜しくお願い致します．